### PR TITLE
Fix example scripts for calculating flux

### DIFF
--- a/myapp/fluxSolver.py
+++ b/myapp/fluxSolver.py
@@ -17,7 +17,7 @@ def setFakePower(core):
     fuelBlocks = core[0].getBlocks(Flags.FUEL)
     topFuelZ = fuelBlocks[-1].spatialLocator.getGlobalCoordinates()[2]
     bottomFuelZ = fuelBlocks[0].spatialLocator.getGlobalCoordinates()[2]
-    coreMidPlane = topFuelZ - bottomFuelZ / 2.0
+    coreMidPlane = (topFuelZ - bottomFuelZ) / 2.0 + bottomFuelZ
     center = np.array([0, 0, coreMidPlane])
     peakPower = 1e6
     mgFluxBase = np.arange(5)

--- a/myapp/thermalSolver.py
+++ b/myapp/thermalSolver.py
@@ -43,7 +43,7 @@ def computeIdealizedFlow(a):
 
 def computeAxialCoolantTemperature(a, massFlow):
     """Compute block-level coolant inlet/outlet/avg temp and velocity."""
-    # solve q''' = mdot * Cp * dT for dT this time
+    # solve Qdot = mdot * Cp * dT for dT this time
     inlet = inletInC
     for b in a:
         b.p.THcoolantInletT = inlet


### PR DESCRIPTION
The variable `coreMidPlane` is being calculated incorrectly and has been fixed.

In addition, the psuedocode in `thermalSolver` has been updated to reflect the
[doc fix in the ARMI Framework documentation](https://github.com/terrapower/armi/pull/355).